### PR TITLE
Add cli tool to convert message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "validate-docbr>=1.11.1",
 ]
 
+[project.scripts]
+sfnmessages = "sfn_messages.cli:main"
+
 [dependency-groups]
 type = [
     "types-defusedxml >=0.7.0,<0.8",

--- a/src/sfn_messages/cli.py
+++ b/src/sfn_messages/cli.py
@@ -1,0 +1,45 @@
+import json
+import sys
+from argparse import ArgumentParser
+
+from sfn_messages.core import get_message_code, load_message_class
+
+parser = ArgumentParser()
+subparsers = parser.add_subparsers(dest='action', metavar='action')
+
+to_xml = subparsers.add_parser('toxml', help='Convert JSON to XML')
+to_xml.add_argument('-m', '--message-code')
+to_xml.add_argument('-i', '--input', default=0, required=False)
+to_xml.add_argument('-o', '--output', default=1, required=False)
+
+to_json = subparsers.add_parser('tojson', help='Convert XML to JSON')
+to_json.add_argument('-m', '--message-code')
+to_json.add_argument('--indent', type=int, default=None)
+to_json.add_argument('-i', '--input', default=0, required=False)
+to_json.add_argument('-o', '--output', default=1, required=False)
+
+
+def main() -> None:
+    args = parser.parse_args()
+    match args.action:
+        case 'toxml':
+            with open(args.input) as f_input, open(args.output, 'w') as f_output:  # noqa: PTH123
+                input_message = json.loads(f_input.read())
+                message_code = args.message_code if args.message_code else input_message['message_code']
+                message_class = load_message_class(message_code)
+                message = message_class.model_validate(input_message)
+                print(message.to_xml(), file=f_output)
+        case 'tojson':
+            with open(args.input) as f_input, open(args.output, 'w') as f_output:  # noqa: PTH123
+                input_message = f_input.read()
+                message_code = args.message_code if args.message_code else get_message_code(input_message)
+                message_class = load_message_class(message_code)
+                message = message_class.from_xml(input_message)
+                print(message.model_dump_json(indent=args.indent), file=f_output)
+        case _:
+            parser.print_usage()
+            sys.exit(2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Cria ferramenta de linha de comando para converter mensagens entre JSON e XML.

## Exemplos de Uso

Converter de JSON para XML:
```sh
sfnmessages toxml <<EOF
{
    "from_ispb": "00038166",
    "to_ispb": "00000000",
    "system_domain": "SPB01",
    "operation_number": "00000000202501010000001",
    "sequence_number": null,
    "continuation_indicator": null,
    "message_code": "GEN0001R1",
    "issuing_ispb": "00038166",
    "recipient_ispb": "00000000",
    "message": "Teste"
}
EOF
```

Converter de XML para JSON:
```sh
sfnmessages tojson --indent=4 <<EOF
<?xml version="1.0"?>
<DOC xmlns="http://www.bcb.gov.br/GEN/GEN0001.xsd">
  <BCMSG>
    <IdentdEmissor>00038166</IdentdEmissor>
    <IdentdDestinatario>00000000</IdentdDestinatario>
    <DomSist>SPB01</DomSist>
    <NUOp>00000000202501010000001</NUOp>
  </BCMSG>
  <SISMSG>
    <GEN0001R1>
      <CodMsg>GEN0001R1</CodMsg>
      <ISPBEmissor>00038166</ISPBEmissor>
      <ISPBDestinatario>00000000</ISPBDestinatario>
      <MsgECO>Teste</MsgECO>
    </GEN0001R1>
  </SISMSG>
</DOC>
EOF
```