### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sfn-messages"
 version = "0.0.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 urls = {repository = "https://github.com/zander-br/sfn_messages"}
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
@@ -32,7 +32,7 @@ dev = [
 ]
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 line-length = 119
 src = ["src", "tests"]
 

--- a/src/sfn_messages/core/types.py
+++ b/src/sfn_messages/core/types.py
@@ -80,7 +80,7 @@ class AccountType(EnumMixin, StrEnum):
     SAVINGS = 'SAVINGS'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[AccountType, str] | None:
+    def _value_to_xml(cls) -> dict[Self, str] | None:
         return {
             cls.CURRENT: 'CC',
             cls.DEPOSIT: 'CD',
@@ -95,7 +95,7 @@ class PersonType(EnumMixin, StrEnum):
     INDIVIDUAL = 'INDIVIDUAL'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[PersonType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.BUSINESS: 'J',
             cls.INDIVIDUAL: 'F',
@@ -206,7 +206,7 @@ class CustomerPurpose(EnumMixin, StrEnum):
     OTHERS = 'OTHERS'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[CustomerPurpose, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.TAX_PAYMENT: '1',
             cls.CREDIT_IN_ACCOUNT: '10',
@@ -327,7 +327,7 @@ class Priority(EnumMixin, StrEnum):
     MEDIUM = 'MEDIUM'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[Priority, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.HIGH: 'B',
             cls.HIGHEST: 'A',
@@ -357,7 +357,7 @@ class StrSettlementStatus(EnumMixin, StrEnum):
     REJECTED_NO_FUNDS = 'REJECTED_NO_FUNDS'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[StrSettlementStatus, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.CANCELED: '14',
             cls.CANCELED_CONTINGENCY: '15',
@@ -426,7 +426,7 @@ class TransferReturnReason(EnumMixin, StrEnum):
     FRAUD_RETURN = 'FRAUD_RETURN'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[TransferReturnReason, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.DESTINATION_ACCOUNT_CLOSED: '1',
             cls.INVALID_JUDICIAL_DEPOSIT_ID: '15',
@@ -726,7 +726,7 @@ class ProductCode(EnumMixin, StrEnum):
     VISA_INTL_DEBIT_PURCHASE = 'VISA_INTL_DEBIT_PURCHASE'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[ProductCode, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.AMEX_CREDIT_CARD: 'ACC',
             cls.BANESCARD_CREDIT_CARD: 'BCC',
@@ -1044,7 +1044,7 @@ class GridCode(EnumMixin, StrEnum):
     TES_RETURN_OF_COLLECTION = 'TES_RETURN_OF_COLLECTION'  # TES12
 
     @classmethod
-    def _value_to_xml(cls) -> dict[GridCode, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             # AGE
             cls.PAYMENT_ORDER_SCHEDULING: 'AGE01',
@@ -1267,7 +1267,7 @@ class TimeType(EnumMixin, StrEnum):
     STANDARD = 'STANDARD'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[TimeType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.EVENTUAL_EXCEPTION: 'E',
             cls.STANDARD: 'P',
@@ -1279,7 +1279,7 @@ class CreditDebitType(EnumMixin, StrEnum):
     DEBIT = 'DEBIT'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[CreditDebitType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {cls.CREDIT: 'C', cls.DEBIT: 'D'}
 
 
@@ -1419,7 +1419,7 @@ class AssetType(EnumMixin, StrEnum):
     WARRANT = 'WARRANT'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[AssetType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.STOCKS: 'ACAO',
             cls.INVESTMENT_PORTFOLIO_ASSETS: 'ACI',
@@ -1586,7 +1586,7 @@ class LdlSettlementStatus(EnumMixin, StrEnum):
     REJECTED_NO_BALANCE_CONTINGENCY = 'REJECTED_NO_BALANCE_CONTINGENCY'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[LdlSettlementStatus, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.EFFECTIVE: '1',
             cls.CANCELLED: '14',
@@ -1622,7 +1622,7 @@ class PaymentType(EnumMixin, StrEnum):
     OTHER = 'OTHER'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[PaymentType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.NOT_APPLICABLE: '0',
             cls.INTEREST_PAYMENT: '1',
@@ -1664,7 +1664,7 @@ class MovementType(EnumMixin, StrEnum):
     SPIN_OFF = 'SPIN_OFF'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[MovementType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.DEPOSIT_OF_ASSET: '1',
             cls.ISIN_CODE_UPDATE: '10',
@@ -1740,7 +1740,7 @@ class InformationType(EnumMixin, StrEnum):
     RECALCULATION = 'RECALCULATION'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[InformationType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.COMPLEMENTARY: 'C',
             cls.DEFINITIVE: 'D',
@@ -1760,7 +1760,7 @@ class ReconciliationType(EnumMixin, StrEnum):
     DIFFER = 'DIFFER'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[ReconciliationType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {cls.CONFIRM: 'C', cls.DIFFER: 'D'}
 
 
@@ -1771,7 +1771,7 @@ class ReturnType(EnumMixin, StrEnum):
     XML_FILE_FTP = 'XML_FILE_FTP'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[ReturnType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.MESSAGE: 'M',
             cls.POSITIONAL_FILE_FTP: 'P',
@@ -1790,7 +1790,7 @@ class ContinuationIndicator(EnumMixin, StrEnum):
     NO = 'NO'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[ContinuationIndicator, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {cls.YES: 'S', cls.NO: 'N'}
 
     def to_bool(self) -> bool:

--- a/src/sfn_messages/gen/types.py
+++ b/src/sfn_messages/gen/types.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import GetPydanticSchema
 from pydantic_core import core_schema
@@ -16,7 +16,7 @@ class CertificateIssue(EnumMixin, StrEnum):
     AC_SOLUTI = 'AC_SOLUTI'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[CertificateIssue, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.SERPRO: '1',
             cls.CERTISIGN: '2',
@@ -68,7 +68,7 @@ class TransmissionType(EnumMixin, StrEnum):
     USERMSG_ATTACHED = 'USERMSG_ATTACHED'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[TransmissionType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.EXTERNAL_AND_USERMSG_ATTACHED: 'A',
             cls.EXTERNAL: 'E',
@@ -109,7 +109,7 @@ class ResponsibleType(EnumMixin, StrEnum):
     ISSUER = 'ISSUER'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[ResponsibleType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.CONTINGENCY_STR: 'C',
             cls.SPB_DIRECTOR: 'D',

--- a/src/sfn_messages/lpi/types.py
+++ b/src/sfn_messages/lpi/types.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Self
 
 from sfn_messages.core.types import EnumMixin
 
@@ -8,7 +9,7 @@ class LpiPurpose(EnumMixin, StrEnum):
     RETURN_OF_IMPROPERLY_RECEIVED_CONTRIBUTION = 'RETURN_OF_IMPROPERLY_RECEIVED_CONTRIBUTION'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[LpiPurpose, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.OWN_MOVEMENT_OR_TO_SETTLER_ACCOUNT_ON_STR: '1',
             cls.RETURN_OF_IMPROPERLY_RECEIVED_CONTRIBUTION: '2',

--- a/src/sfn_messages/ltr/types.py
+++ b/src/sfn_messages/ltr/types.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Self
 
 from sfn_messages.core.types import EnumMixin
 
@@ -10,5 +11,5 @@ class LtrOperationType(EnumMixin, StrEnum):
     EVENT_ASSOCIATION = 'EVENT_ASSOCIATION'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[LtrOperationType, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {cls.NORMAL: '0', cls.COAST: '1', cls.ASSOCIATED: '2', cls.EVENT_ASSOCIATION: '3'}

--- a/src/sfn_messages/slb/types.py
+++ b/src/sfn_messages/slb/types.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import GetPydanticSchema
 from pydantic_core import core_schema
@@ -38,7 +38,7 @@ class SlbSettlementStatus(EnumMixin, StrEnum):
     REJECTED_NO_BALANCE_CONTINGENCY = 'REJECTED_NO_BALANCE_CONTINGENCY'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[SlbSettlementStatus, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.EFFECTED: '1',
             cls.TO_DEBIT: '10',
@@ -598,7 +598,7 @@ class SlbPurpose(EnumMixin, StrEnum):
     )
 
     @classmethod
-    def _value_to_xml(cls) -> dict[SlbPurpose, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.BCB_FX_PURCHASE_SPOT_CREDIT_REAIS_TO_FI: 'CAM060164',
             cls.BCB_FX_SALE_DOMESTIC_RECEIPT_OF_REAIS_FROM_FI: 'CAM060195',

--- a/src/sfn_messages/str/types.py
+++ b/src/sfn_messages/str/types.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import GetPydanticSchema
 from pydantic_core import core_schema
@@ -160,7 +160,7 @@ class InstitutionPurpose(EnumMixin, StrEnum):
     OTHERS = 'OTHERS'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[InstitutionPurpose, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.FX_INTERBANK_MARKET: '1',
             cls.LAW_8727_REPASSES: '10',
@@ -324,7 +324,7 @@ class PortabilityReturnReason(EnumMixin, StrEnum):
     PORTABILITY_ALREADY_SETTLED_BY_ORIGINAL_CREDITOR = 'PORTABILITY_ALREADY_SETTLED_BY_ORIGINAL_CREDITOR'
 
     @classmethod
-    def _value_to_xml(cls) -> dict[PortabilityReturnReason, str]:
+    def _value_to_xml(cls) -> dict[Self, str]:
         return {
             cls.DESTINATION_ACCOUNT_CLOSED: '1',
             cls.INVALID_DESTINATION_AGENCY_OR_ACCOUNT: '2',

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Self
 from xml.etree import ElementTree as ET
 
 import pytest
@@ -122,7 +122,7 @@ class TestXmlSerializerMixin:
                 return root
 
             @classmethod
-            def from_xml_value(cls, xml_value: str | ET.Element) -> SutField:
+            def from_xml_value(cls, xml_value: str | ET.Element) -> Self:
                 raise NotImplementedError
 
         class Sut(XmlSerializerMixin):


### PR DESCRIPTION
Adiciona suporte ao Python 3.12, permitindo instalar e usar como ferramenta de CLI em distribuições como Ubuntu 24.04 LTS (Python 3.12) e Debian Trixie Stable (Python 3.13).

## Validar

O pacote pode ser instalado dentro de um container docker e executado. Exemplo:
```sh
docker run -it --rm debian:trixie-slim bash
apt update
apt install --no-install-recommends pipx git
export PATH="/root/.local/bin/:$PATH"

python3 --version
pipx install git+https://github.com/zander-br/sfn_messages.git@support-python-3.12
sfnmessages --help
```